### PR TITLE
Made performance tests more robust

### DIFF
--- a/test/test_buffer_binary_performance.cc
+++ b/test/test_buffer_binary_performance.cc
@@ -15,7 +15,7 @@ extern "C"
 }
 #include <torch/torch.h>
 
-#define CASES 4
+#define CASES 5
 
 #define MEASUREMENT_ITERS 15
 
@@ -32,11 +32,15 @@ view_t *returned_views[RUNTIMES][DATATYPES][CASES][MEASUREMENT_ITERS];
 torch::Tensor tensors_x[RUNTIMES][DATATYPES][CASES][MEASUREMENT_ITERS];
 torch::Tensor tensors_y[RUNTIMES][DATATYPES][CASES][MEASUREMENT_ITERS];
 
+torch::Device device_cuda(torch::kCUDA);
+torch::Device device_cpu(torch::kCPU);
+
 std::vector<int64_t> shapes[CASES] = {
-    {1, 1},
-    {2, 2},
-    {3, 3},
-    {4, 4},
+    {1,   1},
+    {2,   2},
+    {3,   3},
+    {32,  32},
+    {128, 128},
 };
 
 void setup(void)
@@ -65,15 +69,32 @@ void setup(void)
             {
                 for (int z = 0; z < MEASUREMENT_ITERS; ++z)
                 {
+                    // aten::empty.memory_format not supported for cuda 
                     switch ((datatype_t) j)
                     {
                     case FLOAT32:
-                        tensors_x[i][j][k][z] = torch::randn(shapes[k], torch::TensorOptions().dtype(torch::kFloat32));
-                        tensors_y[i][j][k][z] = torch::randn(shapes[k], torch::TensorOptions().dtype(torch::kFloat32));
+                        tensors_x[i][j][k][z] = torch::randn(shapes[k],
+                                torch::TensorOptions()
+                                .dtype(torch::kFloat32)
+                                // .device(((runtime_t) i == CU_RUNTIME) ? device_cuda : device_cpu)
+                                );
+                        tensors_y[i][j][k][z] = torch::randn(shapes[k],
+                                torch::TensorOptions()
+                                .dtype(torch::kFloat32)
+                                // .device(((runtime_t) i == CU_RUNTIME) ? device_cuda : device_cpu)
+                                );
                         break;
                     case FLOAT64:
-                        tensors_x[i][j][k][z] = torch::randn(shapes[k], torch::TensorOptions().dtype(torch::kFloat64));
-                        tensors_y[i][j][k][z] = torch::randn(shapes[k], torch::TensorOptions().dtype(torch::kFloat64));
+                        tensors_x[i][j][k][z] = torch::randn(shapes[k],
+                                torch::TensorOptions()
+                                .dtype(torch::kFloat64)
+                                // .device(((runtime_t) i == CU_RUNTIME) ? device_cuda : device_cpu)
+                                );
+                        tensors_y[i][j][k][z] = torch::randn(shapes[k],
+                                torch::TensorOptions()
+                                .dtype(torch::kFloat64)
+                                // .device(((runtime_t) i == CU_RUNTIME) ? device_cuda : device_cpu)
+                                );
                         break;
                     default:
                         ck_abort_msg("unknown datatype.");
@@ -151,12 +172,54 @@ void teardown(void)
     error_destroy(error);
 }
 
+void print_heuristics(float64_t torch_time_mkl, float64_t torch_time_cuda,
+        float64_t nw_time_mkl, float64_t nw_time_openblas,
+        float64_t nw_time_cuda)
+{
+    printf("MKL:\n");
+    printf("PyTorch performance (nsec): %0.2lf\n", torch_time_mkl);
+    printf("NW performance (nsec): %0.2lf\n", nw_time_mkl);
+    printf("Fraction (NW nsec/Pytorch nsec): %0.3lf\n\n", nw_time_mkl / torch_time_mkl);
+    printf("OpenBLAS:\n");
+    printf("NW performance (nsec): %0.2lf\n\n", nw_time_openblas);
+    printf("CUDA:\n");
+
+    // aten::empty.memory_format not supported for cuda 
+    
+    // printf("PyTorch performance (nsec): %0.2lf\n", torch_time_cuda);
+    printf("NW performance (nsec): %0.2lf\n\n", nw_time_cuda);
+    // printf("Fraction (NW nsec/Pytorch nsec): %0.3lf\n\n", nw_time_cuda / torch_time_cuda);
+}
+
+void print_heuristics(float64_t torch_time_mkl, float64_t torch_flops_mkl,
+        float64_t torch_time_cuda, float64_t torch_flops_cuda,
+        float64_t nw_time_mkl, float64_t nw_flops_mkl,
+        float64_t nw_time_openblas, float64_t nw_flops_openblas,
+        float64_t nw_time_cuda, float64_t nw_flops_cuda)
+{
+    printf("MKL:\n");
+    printf("PyTorch performance: %0.2lf nsec, %0.2lf FLOPS\n", torch_time_mkl, torch_flops_mkl);
+    printf("NW exponential performance: %0.2lf nsec, %0.2lf FLOPS\n", nw_time_mkl, nw_flops_mkl);
+    printf("Fraction (NW nsec/Pytorch nsec): %0.3lf\n\n", nw_time_mkl / torch_time_mkl);
+    printf("OpenBLAS:\n");
+    printf("NW exponential performance: %0.2lf nsec, %0.2lf FLOPS\n\n", nw_time_openblas, nw_flops_openblas);
+    printf("CUDA:\n");
+
+    // aten::empty.memory_format not supported for cuda 
+
+    // printf("PyTorch performance: %0.2lf nsec, %0.2lf FLOPS\n", torch_time_cuda, torch_flops_cuda);
+    printf("NW exponential performance: %0.2lf nsec, %0.2lf FLOPS\n\n", nw_time_cuda, nw_flops_cuda);
+    // printf("Fraction (NW nsec/Pytorch nsec): %0.3lf\n\n", nw_time_cuda / torch_time_cuda);
+}
+
 START_TEST(test_addition_computational_performance)
 {
-    float64_t torch_avg_perf = 0;
-    float64_t torch_avg_flops = 0;
-    float64_t nw_avg_perf = 0;
-    float64_t nw_avg_flops = 0;
+    float64_t torch_time_mkl = 0, torch_time_cuda = 0;
+    float64_t torch_flops_mkl = 0, torch_flops_cuda = 0;
+    float64_t nw_time_mkl = 0, nw_time_openblas = 0, nw_time_cuda = 0;
+    float64_t nw_flops_mkl = 0, nw_flops_openblas = 0, nw_flops_cuda = 0;
+    uint32_t runtime_total_runs = DATATYPES * CASES * MEASUREMENT_ITERS;
+
     for (int i = 0; i < RUNTIMES; ++i)
     {
         for (int j = 0; j < DATATYPES; ++j)
@@ -171,7 +234,6 @@ START_TEST(test_addition_computational_performance)
                     uint64_t torch_completion_time;
                     uint64_t nw_start, nw_end;
                     uint64_t nw_completion_time;
-                    uint32_t total_runs = RUNTIMES * DATATYPES * CASES * MEASUREMENT_ITERS;
 
                     torch_start = get_time_nanoseconds();
                     torch::Tensor expected_tensor = torch::add(tensors_x[i][j][k][z], tensors_y[i][j][k][z]);
@@ -185,29 +247,52 @@ START_TEST(test_addition_computational_performance)
                     torch_completion_time = torch_end - torch_start;
                     nw_completion_time = nw_end - nw_start;
 
-                    torch_avg_perf += (float64_t) torch_completion_time / total_runs;
-                    torch_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
-                    nw_avg_perf += (float64_t) nw_completion_time / total_runs;
-                    nw_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
+                    switch ((runtime_t) i)
+                    {
+                        case OPENBLAS_RUNTIME:
+                            // Pytorch uses MKL on CPU
+
+                            nw_time_openblas += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_openblas += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case MKL_RUNTIME:
+                            // Torch MKL gets double the runs as a biproduct of
+                            // how the tests are setup.
+
+                            torch_time_mkl += (float64_t) torch_completion_time / (2 * runtime_total_runs);
+                            torch_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * 2 * runtime_total_runs);
+                            nw_time_mkl += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case CU_RUNTIME:
+                            torch_time_cuda += (float64_t) torch_completion_time / runtime_total_runs;
+                            torch_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * runtime_total_runs);
+                            nw_time_cuda += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        default:
+                        ck_abort_msg("unknown runtime.");
+                    }
                 }
             }
         }
     }
 
-    printf("PyTorch addition performance (nsec): %0.2lf\n", torch_avg_perf);
-    printf("NW addition performance (nsec): %0.2lf\n", nw_avg_perf);
-    printf("Fraction (NW nsec/Pytorch nsec): %0.3lf\n", nw_avg_perf / torch_avg_perf);
-    printf("PyTorch FLOPS: %0.2lf\n", torch_avg_flops);
-    printf("NW FLOPS: %0.2lf\n\n", nw_avg_flops);
+    printf("----------------------   Addition   ----------------------\n");
+    print_heuristics(torch_time_mkl, torch_flops_mkl, torch_time_cuda,
+            torch_flops_cuda, nw_time_mkl, nw_flops_mkl, nw_time_openblas,
+            nw_flops_openblas, nw_time_cuda, nw_flops_cuda);
 }
 END_TEST
 
 START_TEST(test_subtraction_computational_performance)
 {
-    float64_t torch_avg_perf = 0;
-    float64_t torch_avg_flops = 0;
-    float64_t nw_avg_perf = 0;
-    float64_t nw_avg_flops = 0;
+    float64_t torch_time_mkl = 0, torch_time_cuda = 0;
+    float64_t torch_flops_mkl = 0, torch_flops_cuda = 0;
+    float64_t nw_time_mkl = 0, nw_time_openblas = 0, nw_time_cuda = 0;
+    float64_t nw_flops_mkl = 0, nw_flops_openblas = 0, nw_flops_cuda = 0;
+    uint32_t runtime_total_runs = DATATYPES * CASES * MEASUREMENT_ITERS;
+
     for (int i = 0; i < RUNTIMES; ++i)
     {
         for (int j = 0; j < DATATYPES; ++j)
@@ -222,7 +307,6 @@ START_TEST(test_subtraction_computational_performance)
                     uint64_t torch_completion_time;
                     uint64_t nw_start, nw_end;
                     uint64_t nw_completion_time;
-                    uint32_t total_runs = RUNTIMES * DATATYPES * CASES * MEASUREMENT_ITERS;
 
                     torch_start = get_time_nanoseconds();
                     torch::Tensor expected_tensor = torch::subtract(tensors_x[i][j][k][z], tensors_y[i][j][k][z]);
@@ -236,29 +320,52 @@ START_TEST(test_subtraction_computational_performance)
                     torch_completion_time = torch_end - torch_start;
                     nw_completion_time = nw_end - nw_start;
 
-                    torch_avg_perf += (float64_t) torch_completion_time / total_runs;
-                    torch_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
-                    nw_avg_perf += (float64_t) nw_completion_time / total_runs;
-                    nw_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
+                    switch ((runtime_t) i)
+                    {
+                        case OPENBLAS_RUNTIME:
+                            // Pytorch uses MKL on CPU
+
+                            nw_time_openblas += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_openblas += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case MKL_RUNTIME:
+                            // Torch MKL gets double the runs as a biproduct of
+                            // how the tests are setup.
+
+                            torch_time_mkl += (float64_t) torch_completion_time / (2 * runtime_total_runs);
+                            torch_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * 2 * runtime_total_runs);
+                            nw_time_mkl += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case CU_RUNTIME:
+                            torch_time_cuda += (float64_t) torch_completion_time / runtime_total_runs;
+                            torch_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * runtime_total_runs);
+                            nw_time_cuda += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        default:
+                        ck_abort_msg("unknown runtime.");
+                    }
                 }
             }
         }
     }
 
-    printf("PyTorch subtraction performance (nsec): %0.2lf\n", torch_avg_perf);
-    printf("NW subtraction performance (nsec): %0.2lf\n", nw_avg_perf);
-    printf("Fraction (NW nsec/Pytorch nsec): %0.3lf\n", nw_avg_perf / torch_avg_perf);
-    printf("PyTorch FLOPS: %0.2lf\n", torch_avg_flops);
-    printf("NW FLOPS: %0.2lf\n\n", nw_avg_flops);
+    printf("--------------------   Subtraction   ---------------------\n");
+    print_heuristics(torch_time_mkl, torch_flops_mkl, torch_time_cuda,
+            torch_flops_cuda, nw_time_mkl, nw_flops_mkl, nw_time_openblas,
+            nw_flops_openblas, nw_time_cuda, nw_flops_cuda);
 }
 END_TEST
 
 START_TEST(test_multiplication_computational_performance)
 {
-    float64_t torch_avg_perf = 0;
-    float64_t torch_avg_flops = 0;
-    float64_t nw_avg_perf = 0;
-    float64_t nw_avg_flops = 0;
+    float64_t torch_time_mkl = 0, torch_time_cuda = 0;
+    float64_t torch_flops_mkl = 0, torch_flops_cuda = 0;
+    float64_t nw_time_mkl = 0, nw_time_openblas = 0, nw_time_cuda = 0;
+    float64_t nw_flops_mkl = 0, nw_flops_openblas = 0, nw_flops_cuda = 0;
+    uint32_t runtime_total_runs = DATATYPES * CASES * MEASUREMENT_ITERS;
+
     for (int i = 0; i < RUNTIMES; ++i)
     {
         for (int j = 0; j < DATATYPES; ++j)
@@ -273,7 +380,6 @@ START_TEST(test_multiplication_computational_performance)
                     uint64_t torch_completion_time;
                     uint64_t nw_start, nw_end;
                     uint64_t nw_completion_time;
-                    uint32_t total_runs = RUNTIMES * DATATYPES * CASES * MEASUREMENT_ITERS;
 
                     torch_start = get_time_nanoseconds();
                     torch::Tensor expected_tensor = torch::mul(tensors_x[i][j][k][z], tensors_y[i][j][k][z]);
@@ -287,29 +393,52 @@ START_TEST(test_multiplication_computational_performance)
                     torch_completion_time = torch_end - torch_start;
                     nw_completion_time = nw_end - nw_start;
 
-                    torch_avg_perf += (float64_t) torch_completion_time / total_runs;
-                    torch_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
-                    nw_avg_perf += (float64_t) nw_completion_time / total_runs;
-                    nw_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
+                    switch ((runtime_t) i)
+                    {
+                        case OPENBLAS_RUNTIME:
+                            // Pytorch uses MKL on CPU
+
+                            nw_time_openblas += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_openblas += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case MKL_RUNTIME:
+                            // Torch MKL gets double the runs as a biproduct of
+                            // how the tests are setup.
+
+                            torch_time_mkl += (float64_t) torch_completion_time / (2 * runtime_total_runs);
+                            torch_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * 2 * runtime_total_runs);
+                            nw_time_mkl += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case CU_RUNTIME:
+                            torch_time_cuda += (float64_t) torch_completion_time / runtime_total_runs;
+                            torch_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * runtime_total_runs);
+                            nw_time_cuda += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        default:
+                        ck_abort_msg("unknown runtime.");
+                    }
                 }
             }
         }
     }
 
-    printf("PyTorch multiplication performance (nsec): %0.2lf\n", torch_avg_perf);
-    printf("NW multiplication performance (nsec): %0.2lf\n", nw_avg_perf);
-    printf("Fraction (NW nsec/Pytorch nsec): %0.3lf\n", nw_avg_perf / torch_avg_perf);
-    printf("PyTorch FLOPS: %0.2lf\n", torch_avg_flops);
-    printf("NW FLOPS: %0.2lf\n\n", nw_avg_flops);
+    printf("-------------------   Multiplication   -------------------\n");
+    print_heuristics(torch_time_mkl, torch_flops_mkl, torch_time_cuda,
+            torch_flops_cuda, nw_time_mkl, nw_flops_mkl, nw_time_openblas,
+            nw_flops_openblas, nw_time_cuda, nw_flops_cuda);
 }
 END_TEST
 
 START_TEST(test_division_computational_performance)
 {
-    float64_t torch_avg_perf = 0;
-    float64_t torch_avg_flops = 0;
-    float64_t nw_avg_perf = 0;
-    float64_t nw_avg_flops = 0;
+    float64_t torch_time_mkl = 0, torch_time_cuda = 0;
+    float64_t torch_flops_mkl = 0, torch_flops_cuda = 0;
+    float64_t nw_time_mkl = 0, nw_time_openblas = 0, nw_time_cuda = 0;
+    float64_t nw_flops_mkl = 0, nw_flops_openblas = 0, nw_flops_cuda = 0;
+    uint32_t runtime_total_runs = DATATYPES * CASES * MEASUREMENT_ITERS;
+
     for (int i = 0; i < RUNTIMES; ++i)
     {
         for (int j = 0; j < DATATYPES; ++j)
@@ -324,7 +453,6 @@ START_TEST(test_division_computational_performance)
                     uint64_t torch_completion_time;
                     uint64_t nw_start, nw_end;
                     uint64_t nw_completion_time;
-                    uint32_t total_runs = RUNTIMES * DATATYPES * CASES * MEASUREMENT_ITERS;
 
                     torch_start = get_time_nanoseconds();
                     torch::Tensor expected_tensor = torch::div(tensors_x[i][j][k][z], tensors_y[i][j][k][z]);
@@ -338,27 +466,50 @@ START_TEST(test_division_computational_performance)
                     torch_completion_time = torch_end - torch_start;
                     nw_completion_time = nw_end - nw_start;
 
-                    torch_avg_perf += (float64_t) torch_completion_time / total_runs;
-                    torch_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
-                    nw_avg_perf += (float64_t) nw_completion_time / total_runs;
-                    nw_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
+                    switch ((runtime_t) i)
+                    {
+                        case OPENBLAS_RUNTIME:
+                            // Pytorch uses MKL on CPU
+
+                            nw_time_openblas += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_openblas += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case MKL_RUNTIME:
+                            // Torch MKL gets double the runs as a biproduct of
+                            // how the tests are setup.
+
+                            torch_time_mkl += (float64_t) torch_completion_time / (2 * runtime_total_runs);
+                            torch_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * 2 * runtime_total_runs);
+                            nw_time_mkl += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case CU_RUNTIME:
+                            torch_time_cuda += (float64_t) torch_completion_time / runtime_total_runs;
+                            torch_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * runtime_total_runs);
+                            nw_time_cuda += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        default:
+                        ck_abort_msg("unknown runtime.");
+                    }
                 }
             }
         }
     }
 
-    printf("PyTorch division performance (nsec): %0.2lf\n", torch_avg_perf);
-    printf("NW division performance (nsec): %0.2lf\n", nw_avg_perf);
-    printf("Fraction (NW nsec/Pytorch nsec): %0.3lf\n", nw_avg_perf / torch_avg_perf);
-    printf("PyTorch FLOPS: %0.2lf\n", torch_avg_flops);
-    printf("NW FLOPS: %0.2lf\n\n", nw_avg_flops);
+    printf("----------------------   Division   ----------------------\n");
+    print_heuristics(torch_time_mkl, torch_flops_mkl, torch_time_cuda,
+            torch_flops_cuda, nw_time_mkl, nw_flops_mkl, nw_time_openblas,
+            nw_flops_openblas, nw_time_cuda, nw_flops_cuda);
 }
 END_TEST
 
 START_TEST(test_power_computational_performance)
 {
-    float64_t torch_avg_perf = 0;
-    float64_t nw_avg_perf = 0;
+    float64_t torch_time_mkl = 0, torch_time_cuda = 0;
+    float64_t nw_time_mkl = 0, nw_time_openblas = 0, nw_time_cuda = 0;
+    uint32_t runtime_total_runs = DATATYPES * CASES * MEASUREMENT_ITERS;
+
     for (int i = 0; i < RUNTIMES; ++i)
     {
         for (int j = 0; j < DATATYPES; ++j)
@@ -371,7 +522,6 @@ START_TEST(test_power_computational_performance)
                     uint64_t torch_completion_time;
                     uint64_t nw_start, nw_end;
                     uint64_t nw_completion_time;
-                    uint32_t total_runs = RUNTIMES * DATATYPES * CASES * MEASUREMENT_ITERS;
 
                     torch_start = get_time_nanoseconds();
                     torch::Tensor expected_tensor = torch::pow(tensors_x[i][j][k][z], tensors_y[i][j][k][z]);
@@ -385,25 +535,46 @@ START_TEST(test_power_computational_performance)
                     torch_completion_time = torch_end - torch_start;
                     nw_completion_time = nw_end - nw_start;
 
-                    torch_avg_perf += (float64_t) torch_completion_time / total_runs;
-                    nw_avg_perf += (float64_t) nw_completion_time / total_runs;
+                    switch ((runtime_t) i)
+                    {
+                        case OPENBLAS_RUNTIME:
+                            // Pytorch uses MKL on CPU
+
+                            nw_time_openblas += (float64_t) nw_completion_time / runtime_total_runs;
+                            break;
+                        case MKL_RUNTIME:
+                            // Torch MKL gets double the runs as a biproduct of
+                            // how the tests are setup.
+
+                            torch_time_mkl += (float64_t) torch_completion_time / (2 * runtime_total_runs);
+                            nw_time_mkl += (float64_t) nw_completion_time / runtime_total_runs;
+                            break;
+                        case CU_RUNTIME:
+                            torch_time_cuda += (float64_t) torch_completion_time / runtime_total_runs;
+                            nw_time_cuda += (float64_t) nw_completion_time / runtime_total_runs;
+                            break;
+                        default:
+                        ck_abort_msg("unknown runtime.");
+                    }
                 }
             }
         }
     }
 
-    printf("PyTorch power performance (nsec): %0.2lf\n", torch_avg_perf);
-    printf("NW power performance (nsec): %0.2lf\n", nw_avg_perf);
-    printf("Fraction (NW nsec/Pytorch nsec): %0.3lf\n\n", nw_avg_perf / torch_avg_perf);
+    printf("-----------------------   Power   ------------------------\n");
+    print_heuristics(torch_time_mkl, torch_time_cuda, nw_time_mkl,
+            nw_time_openblas, nw_time_cuda);
 }
 END_TEST
 
 START_TEST(test_compare_equal_computational_performance)
 {
-    float64_t torch_avg_perf = 0;
-    float64_t torch_avg_flops = 0;
-    float64_t nw_avg_perf = 0;
-    float64_t nw_avg_flops = 0;
+    float64_t torch_time_mkl = 0, torch_time_cuda = 0;
+    float64_t torch_flops_mkl = 0, torch_flops_cuda = 0;
+    float64_t nw_time_mkl = 0, nw_time_openblas = 0, nw_time_cuda = 0;
+    float64_t nw_flops_mkl = 0, nw_flops_openblas = 0, nw_flops_cuda = 0;
+    uint32_t runtime_total_runs = DATATYPES * CASES * MEASUREMENT_ITERS;
+
     for (int i = 0; i < RUNTIMES; ++i)
     {
         for (int j = 0; j < DATATYPES; ++j)
@@ -418,7 +589,6 @@ START_TEST(test_compare_equal_computational_performance)
                     uint64_t torch_completion_time;
                     uint64_t nw_start, nw_end;
                     uint64_t nw_completion_time;
-                    uint32_t total_runs = RUNTIMES * DATATYPES * CASES * MEASUREMENT_ITERS;
 
                     torch_start = get_time_nanoseconds();
                     torch::Tensor expected_tensor = torch::eq(tensors_x[i][j][k][z], tensors_y[i][j][k][z]).to(tensors_x[i][j][k][z].dtype());
@@ -432,29 +602,52 @@ START_TEST(test_compare_equal_computational_performance)
                     torch_completion_time = torch_end - torch_start;
                     nw_completion_time = nw_end - nw_start;
 
-                    torch_avg_perf += (float64_t) torch_completion_time / total_runs;
-                    torch_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
-                    nw_avg_perf += (float64_t) nw_completion_time / total_runs;
-                    nw_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
+                    switch ((runtime_t) i)
+                    {
+                        case OPENBLAS_RUNTIME:
+                            // Pytorch uses MKL on CPU
+
+                            nw_time_openblas += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_openblas += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case MKL_RUNTIME:
+                            // Torch MKL gets double the runs as a biproduct of
+                            // how the tests are setup.
+
+                            torch_time_mkl += (float64_t) torch_completion_time / (2 * runtime_total_runs);
+                            torch_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * 2 * runtime_total_runs);
+                            nw_time_mkl += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case CU_RUNTIME:
+                            torch_time_cuda += (float64_t) torch_completion_time / runtime_total_runs;
+                            torch_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * runtime_total_runs);
+                            nw_time_cuda += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        default:
+                        ck_abort_msg("unknown runtime.");
+                    }
                 }
             }
         }
     }
 
-    printf("PyTorch compare equal performance (nsec): %0.2lf\n", torch_avg_perf);
-    printf("NW compare equal performance (nsec): %0.2lf\n", nw_avg_perf);
-    printf("Fraction (NW nsec/Pytorch nsec): %0.3lf\n", nw_avg_perf / torch_avg_perf);
-    printf("PyTorch FLOPS: %0.2lf\n", torch_avg_flops);
-    printf("NW FLOPS: %0.2lf\n\n", nw_avg_flops);
+    printf("-------------------   Compare Equal   --------------------\n");
+    print_heuristics(torch_time_mkl, torch_flops_mkl, torch_time_cuda,
+            torch_flops_cuda, nw_time_mkl, nw_flops_mkl, nw_time_openblas,
+            nw_flops_openblas, nw_time_cuda, nw_flops_cuda);
 }
 END_TEST
 
 START_TEST(test_compare_greater_computational_performance)
 {
-    float64_t torch_avg_perf = 0;
-    float64_t torch_avg_flops = 0;
-    float64_t nw_avg_perf = 0;
-    float64_t nw_avg_flops = 0;
+    float64_t torch_time_mkl = 0, torch_time_cuda = 0;
+    float64_t torch_flops_mkl = 0, torch_flops_cuda = 0;
+    float64_t nw_time_mkl = 0, nw_time_openblas = 0, nw_time_cuda = 0;
+    float64_t nw_flops_mkl = 0, nw_flops_openblas = 0, nw_flops_cuda = 0;
+    uint32_t runtime_total_runs = DATATYPES * CASES * MEASUREMENT_ITERS;
+
     for (int i = 0; i < RUNTIMES; ++i)
     {
         for (int j = 0; j < DATATYPES; ++j)
@@ -469,7 +662,6 @@ START_TEST(test_compare_greater_computational_performance)
                     uint64_t torch_completion_time;
                     uint64_t nw_start, nw_end;
                     uint64_t nw_completion_time;
-                    uint32_t total_runs = RUNTIMES * DATATYPES * CASES * MEASUREMENT_ITERS;
 
                     torch_start = get_time_nanoseconds();
                     torch::Tensor expected_tensor = torch::gt(tensors_x[i][j][k][z], tensors_y[i][j][k][z]).to(tensors_x[i][j][k][z].dtype());
@@ -483,29 +675,52 @@ START_TEST(test_compare_greater_computational_performance)
                     torch_completion_time = torch_end - torch_start;
                     nw_completion_time = nw_end - nw_start;
 
-                    torch_avg_perf += (float64_t) torch_completion_time / total_runs;
-                    torch_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
-                    nw_avg_perf += (float64_t) nw_completion_time / total_runs;
-                    nw_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
+                    switch ((runtime_t) i)
+                    {
+                        case OPENBLAS_RUNTIME:
+                            // Pytorch uses MKL on CPU
+
+                            nw_time_openblas += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_openblas += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case MKL_RUNTIME:
+                            // Torch MKL gets double the runs as a biproduct of
+                            // how the tests are setup.
+
+                            torch_time_mkl += (float64_t) torch_completion_time / (2 * runtime_total_runs);
+                            torch_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * 2 * runtime_total_runs);
+                            nw_time_mkl += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case CU_RUNTIME:
+                            torch_time_cuda += (float64_t) torch_completion_time / runtime_total_runs;
+                            torch_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * runtime_total_runs);
+                            nw_time_cuda += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        default:
+                        ck_abort_msg("unknown runtime.");
+                    }
                 }
             }
         }
     }
 
-    printf("PyTorch compare greater performance (nsec): %0.2lf\n", torch_avg_perf);
-    printf("NW compare greater performance (nsec): %0.2lf\n", nw_avg_perf);
-    printf("Fraction (NW nsec/Pytorch nsec): %0.3lf\n", nw_avg_perf / torch_avg_perf);
-    printf("PyTorch FLOPS: %0.2lf\n", torch_avg_flops);
-    printf("NW FLOPS: %0.2lf\n\n", nw_avg_flops);
+    printf("------------------   Compare Greater   -------------------\n");
+    print_heuristics(torch_time_mkl, torch_flops_mkl, torch_time_cuda,
+            torch_flops_cuda, nw_time_mkl, nw_flops_mkl, nw_time_openblas,
+            nw_flops_openblas, nw_time_cuda, nw_flops_cuda);
 }
 END_TEST
 
 START_TEST(test_matrix_multiplication_computational_performance)
 {
-    float64_t torch_avg_perf = 0;
-    float64_t torch_avg_flops = 0;
-    float64_t nw_avg_perf = 0;
-    float64_t nw_avg_flops = 0;
+    float64_t torch_time_mkl = 0, torch_time_cuda = 0;
+    float64_t torch_flops_mkl = 0, torch_flops_cuda = 0;
+    float64_t nw_time_mkl = 0, nw_time_openblas = 0, nw_time_cuda = 0;
+    float64_t nw_flops_mkl = 0, nw_flops_openblas = 0, nw_flops_cuda = 0;
+    uint32_t runtime_total_runs = DATATYPES * CASES * MEASUREMENT_ITERS;
+
     for (int i = 0; i < RUNTIMES; ++i)
     {
         for (int j = 0; j < DATATYPES; ++j)
@@ -522,7 +737,6 @@ START_TEST(test_matrix_multiplication_computational_performance)
                     uint64_t torch_completion_time;
                     uint64_t nw_start, nw_end;
                     uint64_t nw_completion_time;
-                    uint32_t total_runs = RUNTIMES * DATATYPES * CASES * MEASUREMENT_ITERS;
 
                     torch_start = get_time_nanoseconds();
                     torch::Tensor expected_tensor = torch::matmul(tensors_x[i][j][k][z], tensors_y[i][j][k][z]);
@@ -536,20 +750,41 @@ START_TEST(test_matrix_multiplication_computational_performance)
                     torch_completion_time = torch_end - torch_start;
                     nw_completion_time = nw_end - nw_start;
 
-                    torch_avg_perf += (float64_t) torch_completion_time / total_runs;
-                    torch_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
-                    nw_avg_perf += (float64_t) nw_completion_time / total_runs;
-                    nw_avg_flops += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * total_runs);
+                    switch ((runtime_t) i)
+                    {
+                        case OPENBLAS_RUNTIME:
+                            // Pytorch uses MKL on CPU
+
+                            nw_time_openblas += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_openblas += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case MKL_RUNTIME:
+                            // Torch MKL gets double the runs as a biproduct of
+                            // how the tests are setup.
+
+                            torch_time_mkl += (float64_t) torch_completion_time / (2 * runtime_total_runs);
+                            torch_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * 2 * runtime_total_runs);
+                            nw_time_mkl += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_mkl += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        case CU_RUNTIME:
+                            torch_time_cuda += (float64_t) torch_completion_time / runtime_total_runs;
+                            torch_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) torch_completion_time * runtime_total_runs);
+                            nw_time_cuda += (float64_t) nw_completion_time / runtime_total_runs;
+                            nw_flops_cuda += ((float64_t) num_flop * 1000000000) / ((float64_t) nw_completion_time * runtime_total_runs);
+                            break;
+                        default:
+                        ck_abort_msg("unknown runtime.");
+                    }
                 }
             }
         }
     }
 
-    printf("PyTorch matrix multiplication performance (nsec): %0.2lf\n", torch_avg_perf);
-    printf("NW matrix multiplication performance (nsec): %0.2lf\n", nw_avg_perf);
-    printf("Fraction (NW nsec/Pytorch nsec): %0.3lf\n", nw_avg_perf / torch_avg_perf);
-    printf("PyTorch FLOPS: %0.2lf\n", torch_avg_flops);
-    printf("NW FLOPS: %0.2lf\n\n", nw_avg_flops);
+    printf("------------------   Compare Greater   -------------------\n");
+    print_heuristics(torch_time_mkl, torch_flops_mkl, torch_time_cuda,
+            torch_flops_cuda, nw_time_mkl, nw_flops_mkl, nw_time_openblas,
+            nw_flops_openblas, nw_time_cuda, nw_flops_cuda);
 }
 END_TEST
 

--- a/test/test_buffer_unary_performance.cc
+++ b/test/test_buffer_unary_performance.cc
@@ -28,6 +28,7 @@ view_t *views[RUNTIMES][DATATYPES][CASES][MEASUREMENT_ITERS];
 view_t *returned_views[RUNTIMES][DATATYPES][CASES][MEASUREMENT_ITERS];
 
 torch::Tensor tensors[RUNTIMES][DATATYPES][CASES][MEASUREMENT_ITERS];
+
 torch::Device device_cuda(torch::kCUDA);
 torch::Device device_cpu(torch::kCPU);
 


### PR DESCRIPTION
- Runtimes are evaluated individually.
- Pytorch does CPU (MKL) and CUDA runs. CUDA is disabled because some operation is not supported which is causing errors, but I thought it wouldn't hurt to leave that code in for now.
- Issues with the number of FLOP(s) in unary tests resolved.
- Added some cases with tensors at the dimension threshold where the Strassen Algorithm performs better than a (poorly optimized) traditional matrix multiplication algorithm, according to wikipedia.