### PR TITLE
Activations as separate layer and optional NULL Bias

### DIFF
--- a/src/nn/layer.h
+++ b/src/nn/layer.h
@@ -15,7 +15,6 @@ typedef struct linear_t
 {
     tensor_t *weights;
     tensor_t *bias;
-    activation_t *activation;
 } linear_t;
 
 typedef struct convolution_2d_t
@@ -27,7 +26,6 @@ typedef struct convolution_2d_t
     int64_t out_channels;
     tensor_t *kernel;
     tensor_t *bias;
-    activation_t *activation;
 } convolution_2d_t;
 
 typedef struct dropout_t
@@ -42,6 +40,7 @@ typedef union transform_t
     linear_t *linear;
     convolution_2d_t *convolution_2d;
     dropout_t *dropout;
+    activation_t *activation;
     block_t *block;
 } transform_t;
 
@@ -51,6 +50,7 @@ typedef enum transform_type_t
     CONVOLUTION_2D,
     CONVOLUTION_TRANSPOSE_2D,
     DROPOUT,
+    ACTIVATION,
     BLOCK
 } transform_type_t;
 
@@ -85,24 +85,28 @@ nw_error_t *transform_create(transform_t **transform, transform_type_t transform
 void transform_destroy(transform_t *transform, transform_type_t transform_type);
 string_t transform_type_string(transform_type_t transform_type);
 
-nw_error_t *linear_create(linear_t **linear, tensor_t *weights, tensor_t *bias, activation_t *activation);
+nw_error_t *linear_create(linear_t **linear, tensor_t *weights, tensor_t *bias);
 void linear_destroy(linear_t *linear);
 
 nw_error_t *convolution_2d_create(convolution_2d_t **convolution_2d, int64_t kernel_size, int64_t padding, int64_t stride,
-                                  int64_t in_channels, int64_t out_channels, tensor_t *kernel, tensor_t *bias, activation_t *activation);
+                                  int64_t in_channels, int64_t out_channels, tensor_t *kernel, tensor_t *bias);
 void convolution_2d_destroy(convolution_2d_t *convolution_2d);
 
 nw_error_t *dropout_create(dropout_t **dropout, void *probability, datatype_t datatype);
 void dropout_destroy(dropout_t *dropout);
 
 nw_error_t *linear_layer_create(layer_t **layer, int64_t in_features, int64_t out_features, runtime_t runtime, datatype_t datatype,
-                                bool_t requires_gradient, activation_t *activation, parameter_init_t *weight_init, parameter_init_t *bias_init);
+                                parameter_init_t *weight_init, parameter_init_t *bias_init);
+nw_error_t *linear_layer_create_from_parameters(layer_t **layer, tensor_t *weights, tensor_t *bias);
 nw_error_t *convolution_2d_layer_create(layer_t **layer, int64_t kernel_size, int64_t padding, int64_t stride, int64_t in_channels, int64_t out_channels, runtime_t runtime, 
-                                        datatype_t datatype, bool_t requires_gradient, activation_t *activation, parameter_init_t *kernel_init, parameter_init_t *bias_init);
+                                        datatype_t datatype, parameter_init_t *kernel_init, parameter_init_t *bias_init);
 nw_error_t *convolution_2d_transpose_layer_create(layer_t **layer, int64_t kernel_size, int64_t padding, int64_t stride, int64_t in_channels, int64_t out_channels,
-                                                  runtime_t runtime, datatype_t datatype, bool_t requires_gradient, activation_t *activation, parameter_init_t *kernel_init,
-                                                  parameter_init_t *bias_init);
+                                                  runtime_t runtime, datatype_t datatype, parameter_init_t *kernel_init, parameter_init_t *bias_init);
 nw_error_t *dropout_layer_create(layer_t **layer, void *probability, datatype_t datatype);
+nw_error_t *rectified_linear_activation_layer_create(layer_t **layer);
+nw_error_t *sigmoid_activation_layer_create(layer_t **layer);
+nw_error_t *softmax_activation_layer_create(layer_t **layer, int64_t axis);
+nw_error_t *logsoftmax_activation_layer_create(layer_t **layer, int64_t axis);
 
 // Model Forward
 nw_error_t *model_forward(model_t *model, tensor_t *x, tensor_t **y);

--- a/src/nn/train.c
+++ b/src/nn/train.c
@@ -140,6 +140,7 @@ nw_error_t *fit(int64_t epochs,
 
         int64_t start = train_iterations;
         int64_t end = valid_iterations + train_iterations;
+        model_inference(model, true);
 
         for (int64_t j = start; j < end; ++j)
         {
@@ -177,6 +178,7 @@ nw_error_t *fit(int64_t epochs,
             cost = NULL;
         }
 
+        model_inference(model, false);
         with_no_gradient(false);
     }
 

--- a/src/tensor/tensor.h
+++ b/src/tensor/tensor.h
@@ -79,6 +79,7 @@ nw_error_t *tensor_concatenation(const tensor_t *x, const tensor_t *y, tensor_t 
 // Ternary Operations
 nw_error_t *tensor_convolution_2d(const tensor_t *w, const tensor_t *x, const tensor_t *y, tensor_t **z, int64_t stride, int64_t padding);
 nw_error_t *tensor_convolution_2d_transpose(const tensor_t *w, const tensor_t *x, const tensor_t *y, tensor_t **z, int64_t stride, int64_t padding);
+nw_error_t *tensor_linear(const tensor_t *w, const tensor_t *x, const tensor_t *y, tensor_t **z);
 
 // Reduction Operations
 nw_error_t *tensor_summation(const tensor_t *x, tensor_t **y, const int64_t *axis, int64_t length, bool_t keep_dimension);

--- a/src/util/errors.c
+++ b/src/util/errors.c
@@ -193,6 +193,8 @@ string_t error_type_string(nw_error_type_t error_type)
         return "ERROR_SLICE";
     case ERROR_GET:
         return "ERROR_GET";
+    case ERROR_LINEAR:
+        return "ERROR_LINEAR";
     default:
         return "ERROR";
     }

--- a/src/util/errors.h
+++ b/src/util/errors.h
@@ -380,8 +380,6 @@
         PRINT_DEBUG_TENSOR((linear)->weights);\
         fprintf(stderr, ", bias: ");\
         PRINT_DEBUG_TENSOR((linear)->bias);\
-        fprintf(stderr, ", activation: ");\
-        PRINT_DEBUG_ACTIVATION((linear)->activation);\
         fprintf(stderr, ")");\
     }\
 } while(0)
@@ -671,6 +669,7 @@ typedef enum nw_error_type_t
     ERROR_PADDING,
     ERROR_SLICE,
     ERROR_GET,
+    ERROR_LINEAR,
 } nw_error_type_t;
 
 typedef struct nw_error_t

--- a/test/test_optimizer.cc
+++ b/test/test_optimizer.cc
@@ -439,29 +439,19 @@ void setup_model(runtime_t runtime, datatype_t datatype, model_type_t model_type
         tensor_t *bias = torch_to_tensor(torch_bias, runtime, datatype);
         tensor_t *input = torch_to_tensor(torch_input, runtime, datatype);
 
-        activation_t *activation_1 = NULL;
-        linear_t *linear_1 = NULL;
-        transform_t *transform_1 = NULL;
-        layer_t *layer_1 = NULL;
+        layer_t *linear_layer = NULL;
+        layer_t *activation_layer = NULL;
         block_t *block = NULL;
         
-        error = rectified_linear_activation_create(&activation_1);
+        error = rectified_linear_activation_layer_create(&activation_layer);
         ck_assert_ptr_null(error);
-        ck_assert_ptr_nonnull(activation_1);
+        ck_assert_ptr_nonnull(activation_layer);
 
-        error = linear_create(&linear_1, weights, bias, activation_1);
+        error = linear_layer_create_from_parameters(&linear_layer, weights, bias);
         ck_assert_ptr_null(error);
-        ck_assert_ptr_nonnull(activation_1);
+        ck_assert_ptr_nonnull(linear_layer);
 
-        error = transform_create(&transform_1, LINEAR, linear_1);
-        ck_assert_ptr_null(error);
-        ck_assert_ptr_nonnull(linear_1);
-
-        error = layer_create(&layer_1, transform_1, LINEAR);
-        ck_assert_ptr_null(error);
-        ck_assert_ptr_nonnull(layer_1);
-
-        error = block_create(&block, 1, layer_1);
+        error = block_create(&block, 2, linear_layer, activation_layer);
         ck_assert_ptr_null(error);
         ck_assert_ptr_nonnull(block);
 
@@ -590,6 +580,8 @@ void setup_optimizer(algorithm_type_t algorithm_type)
 
 void teardown_optimizer(algorithm_type_t algorithm_type)
 {
+    error_print(error);
+    error_destroy(error);
     for (int i = 0; i < RUNTIMES; ++i)
     {
         for (int j = 0; j < DATATYPES; ++j)


### PR DESCRIPTION
Batch normalization is generally applied before the activation function. Consequently, the activation function needs to be a separate layer decoupled from the linear and convolution layers. Furthermore, when batch normalization is applied, the bias term cancels, so there is no need for a bias term. Support is needed for the bias to be an optional trainable parameter. This PR addresses both of these issues before batch norm is to be implemented.